### PR TITLE
refactoring & scorer

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,54 @@
+name: Python package
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    
+    strategy:
+      matrix:
+        python-version: ['3.8', '3.9', '3.10']
+        java: [11]
+        os: ['ubuntu-latest']
+        architecture: ['x64']
+        terrier: ['snapshot']
+
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    
+    - name: Setup java
+      uses: actions/setup-java@v1
+      with:
+        java-version: ${{ matrix.java }}
+        architecture: ${{ matrix.architecture }}
+    
+    - name: Install Terrier snapshot
+      if: matrix.terrier == '5.4-SNAPSHOT'
+      run: |
+        git clone https://github.com/terrier-org/terrier-core.git
+        cd terrier-core
+        mvn -B -DskipTests install
+
+    - name: Install Python dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install git+https://github.com/naver/splade.git
+        pip install -r requirements.txt
+        pip install --timeout=120 .
+        pip install pytest
+
+    - name: All unit tests
+      env:
+        TERRIER_VERSION: ${{ matrix.terrier }}
+      run: |
+        pytest

--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ import pyterrier as pt
 pt.init()
 
 import pyt_splade
-splade = pyt_splade.SpladeFactory()
+splade = pyt_splade.Splade()
 indexer = pt.IterDictIndexer('./msmarco_psg', pretokenised=True)
 
-indxr_pipe = splade.indexing() >> indexer
+indxr_pipe = splade.doc_encoder() >> indexer
 index_ref = indxr_pipe.index(dataset.get_corpus_iter(), batch_size=128)
 
 ```
@@ -39,7 +39,18 @@ We apply this as a query encoding transformer. It encodes the query into Terrier
 
 ```python
 
-splade_retr = splade.query() >> pt.BatchRetrieve('./msmarco_psg', wmodel='Tf')
+splade_retr = splade.matchop_query_encoder() >> pt.BatchRetrieve('./msmarco_psg', wmodel='Tf')
+
+```
+
+# Scoring
+
+SPLADE can also be used as a text scoring function.
+
+```python
+
+first_stage = ... # e.g., BM25, dense retrieval, etc.
+splade_scorer = first_stage >> pt.text.get_text(dataset, 'text') >> splade.scorer()
 
 ```
 
@@ -49,4 +60,5 @@ We have a demo of PyTerrier_SPLADE at https://huggingface.co/spaces/terrierteam/
 
 # Credits 
 
-Craig Macdonald
+ - Craig Macdonald
+ - Sean MacAvaney

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ An example of a SPLADE indexing and retrieval using PyTerrier transformers.
 We use [Naver's SPLADE repository](https://github.com/naver/splade) as a dependency: 
 
 ```python
+%pip install -q git+https://github.com/terrier-org/pyterrier.git
 %pip install -q git+https://github.com/naver/splade.git
 %pip install -q git+https://github.com/cmacdonald/pyt_splade.git
 ```
@@ -16,7 +17,7 @@ We use [Naver's SPLADE repository](https://github.com/naver/splade) as a depende
 
 Indexing takes place as a pipeline: we apply SPLADE transformation of the documents, which maps raw text into a dictionary of BERT WordPiece tokens and corresponding weights. The underlying indexer, Terrier, cant handle this form directly, so a further transformer (`pyt_splade.toks2doc()`) makes this into a new textual representation.
 
-The Terrier indexer is configured carefully to index tokens unchanged. 
+The Terrier indexer is configured to index tokens unchanged. 
 
 ```python
 
@@ -25,16 +26,14 @@ pt.init(version='snapshot')
 
 import pyt_splade
 factory = pyt_splade.SpladeFactory()
-indexer = pt.IterDictIndexer('./msmarco_psg')
-indexer.setProperty("termpipelines", "")
-indexer.setProperty("tokeniser", "WhitespaceTokeniser")
+indexer = pt.IterDictIndexer('./msmarco_psg', pretokenised=True)
 
-indxr_pipe = (factory.indexing() >> pyt_splade.toks2doc() >> indexer)
+indxr_pipe = factory.indexing() >> indexer
 index_ref = indxr_pipe.index(dataset.get_corpus_iter(), batch_size=128)
 
 ```
 
-NB: This requires a snapshot version of Terrier (c.f. `pt.init(version='snapshot')`)
+NB: This currently requires a snapshot version of PyTerrier and Terrier (c.f.  `pt.init(version='snapshot')`).
 
 # Retrieval
 
@@ -46,10 +45,6 @@ We apply this as a query encoding transformer. It encodes the query into Terrier
 splade_retr = factory.query() >> pt.BatchRetrieve('./msmarco_psg', wmodel='Tf')
 
 ```
-
-# TODO
-
- - expansion?
 
 # Credits 
 

--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ import pyterrer as pt
 pt.init()
 
 import pyt_splade
-factory = pyt_splade.SpladeFactory()
+splade = pyt_splade.SpladeFactory()
 indexer = pt.IterDictIndexer('./msmarco_psg', pretokenised=True)
 
-indxr_pipe = factory.indexing() >> indexer
+indxr_pipe = splade.indexing() >> indexer
 index_ref = indxr_pipe.index(dataset.get_corpus_iter(), batch_size=128)
 
 ```
@@ -39,7 +39,7 @@ We apply this as a query encoding transformer. It encodes the query into Terrier
 
 ```python
 
-splade_retr = factory.query() >> pt.BatchRetrieve('./msmarco_psg', wmodel='Tf')
+splade_retr = splade.query() >> pt.BatchRetrieve('./msmarco_psg', wmodel='Tf')
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ We apply this as a query encoding transformer. It encodes the query into Terrier
 
 ```python
 
-splade_retr = splade.matchop_query_encoder() >> pt.BatchRetrieve('./msmarco_psg', wmodel='Tf')
+splade_retr = splade.query_encoder(matchop=True) >> pt.BatchRetrieve('./msmarco_psg', wmodel='Tf')
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,8 @@ An example of a SPLADE indexing and retrieval using PyTerrier transformers.
 We use [Naver's SPLADE repository](https://github.com/naver/splade) as a dependency: 
 
 ```python
-%pip install -q git+https://github.com/terrier-org/pyterrier.git
-%pip install -q git+https://github.com/naver/splade.git
-%pip install -q git+https://github.com/cmacdonald/pyt_splade.git
+%pip install -q python-terrier
+%pip install -q git+https://github.com/naver/splade.git git+https://github.com/cmacdonald/pyt_splade.git
 ```
 
 # Indexing
@@ -22,7 +21,7 @@ The Terrier indexer is configured to index tokens unchanged.
 ```python
 
 import pyterrer as pt
-pt.init(version='snapshot')
+pt.init()
 
 import pyt_splade
 factory = pyt_splade.SpladeFactory()
@@ -32,8 +31,6 @@ indxr_pipe = factory.indexing() >> indexer
 index_ref = indxr_pipe.index(dataset.get_corpus_iter(), batch_size=128)
 
 ```
-
-NB: This currently requires a snapshot version of PyTerrier and Terrier (c.f.  `pt.init(version='snapshot')`).
 
 # Retrieval
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ splade_retr = splade.query() >> pt.BatchRetrieve('./msmarco_psg', wmodel='Tf')
 
 ```
 
+# Demo
+
+We have a demo of PyTerrier_SPLADE at https://huggingface.co/spaces/terrierteam/splade
+
 # Credits 
 
 Craig Macdonald

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ The Terrier indexer is configured to index tokens unchanged.
 ```python
 
 import pyterrier as pt
-pt.init()
 
 import pyt_splade
 splade = pyt_splade.Splade()
@@ -39,7 +38,7 @@ We apply this as a query encoding transformer. It encodes the query into Terrier
 
 ```python
 
-splade_retr = splade.query_encoder(matchop=True) >> pt.BatchRetrieve('./msmarco_psg', wmodel='Tf')
+splade_retr = splade.query_encoder(matchop=True) >> pt.terrier.Retrieve('./msmarco_psg', wmodel='Tf')
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ We use [Naver's SPLADE repository](https://github.com/naver/splade) as a depende
 
 # Indexing
 
-Indexing takes place as a pipeline: we apply SPLADE transformation of the documents, which maps raw text into a dictionary of BERT WordPiece tokens and corresponding weights. The underlying indexer, Terrier, cant handle this form directly, so a further transformer (`pyt_splade.toks2doc()`) makes this into a new textual representation.
+Indexing takes place as a pipeline: we apply SPLADE transformation of the documents, which maps raw text into a dictionary of BERT WordPiece tokens and corresponding weights. The underlying indexer, Terrier, is configured to handle arbitrary word counts without further tokenisation (`pretokenised=True`).
 
 The Terrier indexer is configured to index tokens unchanged. 
 

--- a/pyt_splade/__init__.py
+++ b/pyt_splade/__init__.py
@@ -52,7 +52,7 @@ class Splade():
             res = res >> MatchOp(mult=matchop_mult)
         return res
 
-    def query(self, batch_size=100, sparse=True, verbose=False, matchop=True, matchop_mult=100) -> pt.Transformer
+    def query(self, batch_size=100, sparse=True, verbose=False, matchop=True, matchop_mult=100) -> pt.Transformer:
         # backward compatible name w/ default matchop=True
         return self.query_encoder(batch_size, sparse, verbose, matchop, matchop_mult)
 

--- a/pyt_splade/__init__.py
+++ b/pyt_splade/__init__.py
@@ -46,12 +46,15 @@ class Splade():
         return SpladeEncoder(self, text_field, 'toks' if sparse else 'doc_vec', 'd', sparse, batch_size, verbose)
     indexing = doc_encoder # backward compatible name
 
-    def query_encoder(self, batch_size=100, sparse=True, verbose=False) -> pt.Transformer:
-        return SpladeEncoder(self, 'query', 'query_toks' if sparse else 'query_vec', 'q', sparse, batch_size, verbose)
+    def query_encoder(self, batch_size=100, sparse=True, verbose=False, matchop=False, matchop_mult=100) -> pt.Transformer:
+        res = SpladeEncoder(self, 'query', 'query_toks' if sparse else 'query_vec', 'q', sparse, batch_size, verbose)
+        if matchop:
+            res = res >> MatchOp(mult=matchop_mult)
+        return res
 
-    def matchop_query_encoder(self, batch_size=100, verbose=False, mult=100) -> pt.Transformer:
-        return self.query_encoder(batch_size, sparse=True, verbose=verbose) >> MatchOp(mult=mult)
-    query = matchop_query_encoder # backward compatible name
+    def query(self, batch_size=100, sparse=True, verbose=False, matchop=True, matchop_mult=100) -> pt.Transformer
+        # backward compatible name w/ default matchop=True
+        return self.query_encoder(batch_size, sparse, verbose, matchop, matchop_mult)
 
     def scorer(self, text_field='text', batch_size=100, verbose=False) -> pt.Transformer:
         return SpladeScorer(self, text_field, batch_size, verbose)

--- a/pyt_splade/__init__.py
+++ b/pyt_splade/__init__.py
@@ -1,21 +1,16 @@
+import base64
+import string
+import more_itertools
 from multiprocessing.sharedctypes import Value
 import pyterrier as pt
 assert pt.started()
 from typing import Union
 import torch
+import numpy as np
 import pandas as pd
 
-def _matchop(t, w):
-    import base64
-    import string
-    if not all(a in string.ascii_letters + string.digits for a in t):
-        encoded = base64.b64encode(t.encode('utf-8')).decode("utf-8") 
-        t = f'#base64({encoded})'
-    if w != 1:
-        t = f'#combine:0={w}({t})'
-    return t
 
-class SpladeFactory():
+class Splade():
 
     def __init__(
         self,
@@ -47,71 +42,122 @@ class SpladeFactory():
 
         self.reverse_voc = {v: k for k, v in self.tokenizer.vocab.items()}
 
-    def indexing(self) -> pt.Transformer:
-        def _transform_indexing(df):
-            rtr = []
-            if len(df) > 0:
-                with torch.no_grad():
-                    # now compute the document representation
-                    doc_reps = self.model(d_kwargs=self.tokenizer(
-                        df.text.tolist(),
-                        add_special_tokens=True,
-                        padding="longest",  # pad to max sequence length in batch
-                        truncation="longest_first",  # truncates to max model length,
-                        max_length=self.max_length,
-                        return_attention_mask=True,
-                        return_tensors="pt",
-                    ).to(self.device))["d_rep"]  # (sparse) doc rep in voc space, shape (docs, 30522,)
+    def doc_encoder(self, field='text', batch_size=100, sparse=True, verbose=False) -> pt.Transformer:
+        return SpladeEncoder(self, field, 'toks' if sparse else 'doc_vec', 'd', sparse, batch_size, verbose)
+    indexing = doc_encoder # backward compatible name
 
-                    for i in range(doc_reps.shape[0]): #for each doc
-                        # get the number of non-zero dimensions in the rep:
-                        col = torch.nonzero(doc_reps[i]).squeeze().cpu().tolist()
+    def query_encoder(self, batch_size=100, sparse=True, verbose=False) -> pt.Transformer:
+        return SpladeEncoder(self, 'query', 'query_toks' if sparse else 'query_vec', 'q', sparse, batch_size, verbose)
 
-                        # now let's create the bow representation as a dictionary               
-                        weights = doc_reps[i,col].cpu().tolist()
-                        d = {self.reverse_voc[k] : v for k, v in sorted(zip(col, weights), key=lambda x: (-x[1], x[0]))}
-                        rtr.append(d)
-            return df.assign(toks=rtr)
-        return pt.apply.generic(_transform_indexing)
+    def matchop_query_encoder(self, batch_size=100, verbose=False, mult=100) -> pt.Transformer:
+        return self.query_encoder(batch_size, sparse=True, verbose=verbose) >> MatchOp(mult=mult)
+    query = matchop_query_encoder # backward compatible name
 
-    
-    def query(self, mult=100) -> pt.Transformer:
-    
-        def _transform_query(df):
-            from pyterrier.model import push_queries
-            new_queries = []
-            if len(df) > 0:
-                with torch.no_grad():
-                    # now compute the query representations
-                    query_reps = self.model(q_kwargs=self.tokenizer(
-                        df['query'].tolist(),
-                        add_special_tokens=True,
-                        padding="longest",  # pad to max sequence length in batch
-                        truncation="longest_first",  # truncates to max model length,
-                        max_length=self.max_length,
-                        return_attention_mask=True,
-                        return_tensors="pt",
-                    ).to(self.device))["q_rep"]  # (sparse) q rep in voc space, shape (queries, 30522,)
-                
-                    for i in range(query_reps.shape[0]): #for each query
-                        # get the number of non-zero dimensions in the rep:
-                        cols = torch.nonzero(query_reps[i]).squeeze().cpu().tolist()
-                        # and corresponding weights               
-                        weights = query_reps[i,cols].cpu().tolist()
+    def scorer(self, field='text', batch_size=100, verbose=False) -> pt.Transformer:
+        return SpladeScorer(self, field, batch_size, verbose)
 
-                        # Now let's create the bow representation in terrier's matchop QL.
-                        # We scale by mult(=100) to better match the quantized weights in 
-                        # the inverted index created by toks2doc(). These defaults match the
-                        # parameters suggested for Anserini in Splade repo, namely
-                        # quantization_factor_document=100 quantization_factor_query=100.
-                        newquery = ' '.join( _matchop(self.reverse_voc[k], v * mult) for k, v in sorted(zip(cols, weights), key=lambda x: (-x[1], x[0])))
-                        new_queries.append(newquery)
-            
-            rtr = push_queries(df)
-            rtr['query'] = new_queries
-            return rtr
-        return pt.apply.generic(_transform_query)
-    
+    def encode(self, texts, rep='d', format='dict'):
+        rtr = []
+        with torch.no_grad():
+            reps = self.model(**{rep+'_kwargs': self.tokenizer(
+                texts,
+                add_special_tokens=True,
+                padding="longest",  # pad to max sequence length in batch
+                truncation="longest_first",  # truncates to max model length,
+                max_length=self.max_length,
+                return_attention_mask=True,
+                return_tensors="pt",
+            ).to(self.device)})[rep+'_rep']
+        if format == 'dict':
+            reps = reps.cpu()
+            for i in range(reps.shape[0]):
+                # get the number of non-zero dimensions in the rep:
+                col = torch.nonzero(reps[i]).squeeze().tolist()
+                # now let's create the bow representation as a dictionary
+                weights = reps[i, col].cpu().tolist()
+                d = {self.reverse_voc[k] : v for k, v in sorted(zip(col, weights), key=lambda x: (-x[1], x[0]))}
+                rtr.append(d)
+        elif format == 'np':
+            reps = reps.cpu().numpy()
+            for i in range(reps.shape[0]):
+                rtr.append(reps[i])
+        elif format == 'torch':
+            rtr = reps
+        return rtr
+
+
+SpladeFactory = Splade # backward compatible name
+
+
+class SpladeEncoder(pt.Transformer):
+    def __init__(self, splade, field, out_field, rep, sparse=True, batch_size=100, verbose=False):
+        self.splade = splade
+        self.field = field
+        self.out_field = out_field
+        self.rep = rep
+        self.sparse = sparse
+        self.batch_size = batch_size
+        self.verbose = verbose
+
+    def transform(self, df):
+        assert self.field in df.columns
+        it = iter(df[self.field])
+        if self.verbose:
+            it = pt.tqdm(it, total=len(df), unit=self.field)
+        res = []
+        for batch in more_itertools.chunked(it, self.batch_size):
+            res.extend(self.splade.encode(batch, self.rep, format='dict' if self.sparse else 'np'))
+        return df.assign(**{self.out_field: res})
+
+
+class SpladeScorer(pt.Transformer):
+    def __init__(self, splade, field, batch_size=100, verbose=False):
+        self.splade = splade
+        self.field = field
+        self.batch_size = batch_size
+        self.verbose = verbose
+
+    def transform(self, df):
+        assert all(f in df.columns for f in ['query', self.field])
+        it = df.groupby('query')
+        if self.verbose:
+            it = pt.tqdm(it, unit='query')
+        res = []
+        for query, df in it:
+            query_enc = self.splade.encode([query], 'q', 'torch')
+            scores = []
+            for batch in more_itertools.chunked(df[self.field], self.batch_size):
+                doc_enc = self.splade.encode(batch, 'd', 'torch')
+                scores.append((query_enc @ doc_enc.T).flatten().cpu().numpy())
+            res.append(df.assign(score=np.concatenate(scores)))
+        res = pd.concat(res)
+        from pyterrier.model import add_ranks
+        res = add_ranks(res)
+        return res
+
+
+class MatchOp(pt.Transformer):
+    def __init__(self, mult=100):
+        self.mult = mult
+
+    def transform(self, df):
+        assert 'query_toks' in df.columns
+        from pyterrier.model import push_queries
+        rtr = push_queries(df)
+        rtr = rtr.assign(query=df.query_toks.apply(lambda toks: ' '.join(_matchop(k, v * self.mult) for k, v in toks.items())))
+        rtr = rtr.drop(columns=['query_toks'])
+        return rtr
+
+
+def _matchop(t, w):
+    if not all(a in string.ascii_letters + string.digits for a in t):
+        encoded = base64.b64encode(t.encode('utf-8')).decode("utf-8")
+        t = f'#base64({encoded})'
+    if w != 1:
+        t = f'#combine:0={w}({t})'
+    return t
+
+
 
 def toks2doc(mult=100):
     

--- a/tests/test_scorer.py
+++ b/tests/test_scorer.py
@@ -1,0 +1,19 @@
+import unittest
+import pandas as pd
+import tempfile
+class TestBasic(unittest.TestCase):
+
+    def setUp(self):
+        import pyterrier as pt
+        if not pt.started():
+            pt.init()
+        import pyt_splade
+        self.factory = pyt_splade.SpladeFactory(device='cpu')
+
+    def test_scorer(self):
+        df = self.factory.scorer()(pd.DataFrame([
+          {'qid': '0', 'query': 'chemical reactions', 'docno' : 'd1', 'text' : 'hello there'},
+          {'qid': '0', 'query': 'chemical reactions', 'docno' : 'd2', 'text' : 'chemistry society'},
+          {'qid': '1', 'query': 'hello', 'docno' : 'd1', 'text' : 'hello there'},
+        ]))
+        print(df)

--- a/tests/test_scorer.py
+++ b/tests/test_scorer.py
@@ -16,4 +16,15 @@ class TestBasic(unittest.TestCase):
           {'qid': '0', 'query': 'chemical reactions', 'docno' : 'd2', 'text' : 'chemistry society'},
           {'qid': '1', 'query': 'hello', 'docno' : 'd1', 'text' : 'hello there'},
         ]))
-        print(df)
+        self.assertAlmostEqual(0., df['score'][0])
+        self.assertAlmostEqual(11.133593, df['score'][1], places=5)
+        self.assertAlmostEqual(17.566324, df['score'][2], places=5)
+        self.assertEqual('0', df['qid'][0])
+        self.assertEqual('0', df['qid'][1])
+        self.assertEqual('1', df['qid'][2])
+        self.assertEqual('d1', df['docno'][0])
+        self.assertEqual('d2', df['docno'][1])
+        self.assertEqual('d1', df['docno'][2])
+        self.assertEqual(1, df['rank'][0])
+        self.assertEqual(0, df['rank'][1])
+        self.assertEqual(0, df['rank'][2])


### PR DESCRIPTION
A bit of refactoring:
 - `SpladeFactory` -> `Splade`
 - `.indexing()` -> `.doc_encoder()`
 - `.query()` -> `.matchop_query_encoder()`
 - a new `.query_encoder()`, which encodes as a dict instead of matchop
 - All old names are aliased to the new names to ensure backward compatibility
 - Split out lambda-defined transformers into first-class transformer classes

Added `.scorer()`, which allows for scoring arbitrary text.

Added `.doc_encoder(sparse=False)` and `.query_encoder(sparse=False)`, which produce `doc_vec` and `query_vec` columns, making them compatible with `pyterrier_dr`'s conventions. (Though since the vector size is rather large, it wouldn't be super valuable.)

Added github action for running tests