### PR TITLE
Fix TypeError when SPLADE outputs a rep that has only one non-zero value in a single dimension

### DIFF
--- a/pyt_splade/__init__.py
+++ b/pyt_splade/__init__.py
@@ -65,6 +65,9 @@ class SpladeFactory():
                     for i in range(doc_reps.shape[0]): #for each doc
                         # get the number of non-zero dimensions in the rep:
                         col = torch.nonzero(doc_reps[i]).squeeze().cpu().tolist()
+                        # col could be int when only 1 dim is non zero in doc_reps[i]
+                        if isinstance(col, int):
+                            col = [col]
 
                         # now let's create the bow representation as a dictionary               
                         weights = doc_reps[i,col].cpu().tolist()
@@ -95,6 +98,10 @@ class SpladeFactory():
                     for i in range(query_reps.shape[0]): #for each query
                         # get the number of non-zero dimensions in the rep:
                         cols = torch.nonzero(query_reps[i]).squeeze().cpu().tolist()
+                        # cols could be int when only 1 dim is non zero in query_reps[i]
+                        if isinstance(cols, int):
+                            cols = [cols]
+
                         # and corresponding weights               
                         weights = query_reps[i,cols].cpu().tolist()
 


### PR DESCRIPTION
Hello, I appreciate you sharing this amazing project!

I found a bug in the conversion process from SPLADE output to tok representation.
When SPLADE output a vector that is non-zero in only one dimension, `torch.nonzero(doc_rep).squeeze().tolist()` would be int.
``` python
>>> doc_rep = torch.tensor([0,0,0,1,0])
>>> torch.nonzero(doc_rep).squeeze()
tensor(3)
>>> torch.nonzero(doc_rep).squeeze().tolist()
3
```

This cause TypeError in `zip(col, weights)` because col (int) is not Iterable.
It is not a frequent error, but it has happened several times.

I fixed this bug by checking the type of `col` and if `col` is int, convert it to a list.

Thanks

